### PR TITLE
You can send request when already friends

### DIFF
--- a/src/lib/friends.js
+++ b/src/lib/friends.js
@@ -151,6 +151,25 @@ export async function sendFriendRequest(senderId, targetId) {
 		return false;
 	}
 
+	const existingFriendship = await prisma.friendship.findMany({
+		where: {
+			OR: [
+				{
+					userId: senderId,
+					friendId: targetId
+				},
+				{
+					userId: targetId,
+					friendId: senderId
+				}
+			]
+		}
+	});
+
+	if (existingFriendship && existingFriendship.length > 0) {
+		return false;
+	}
+
 	// Create the friend request
 	await prisma.friendRequest.create({
 		data: {

--- a/src/lib/friends.js
+++ b/src/lib/friends.js
@@ -89,7 +89,14 @@ export async function findUsers(query, currentUserId) {
 			},
 			friendships: {
 				where: {
-					friendId: currentUserId
+					OR: [
+						{
+							userId: currentUserId,
+						},
+						{
+							friendId: currentUserId
+						}
+					],
 				},
 				select: {
 					id: true
@@ -97,7 +104,14 @@ export async function findUsers(query, currentUserId) {
 			},
 			friendOf: {
 				where: {
-					friendId: currentUserId
+					OR: [
+						{
+							userId: currentUserId,
+						},
+						{
+							friendId: currentUserId
+						}
+					],
 				},
 				select: {
 					id: true


### PR DESCRIPTION
This PR fixes this error caused by wrong checking of prisma and not checking if users are already friends in the add friend api route.